### PR TITLE
French localisation update

### DIFF
--- a/locale/fr/export.dtd
+++ b/locale/fr/export.dtd
@@ -1,20 +1,20 @@
 <!ENTITY newtabtools.export.title "New Tab Tools">
 <!ENTITY newtabtools.export.header "Sélectionnez le contenu à exporter :">
 <!ENTITY newtabtools.import.header "Sélectionnez le contenu à importer :">
-<!ENTITY newtabtools.export.tiles.caption "Sites">
-<!ENTITY newtabtools.export.prefs.pinned "Sites épinglés">
-<!ENTITY newtabtools.export.prefs.blocked "Sites supprimés">
+<!ENTITY newtabtools.export.tiles.caption "Pages">
+<!ENTITY newtabtools.export.prefs.pinned "Pages épinglées">
+<!ENTITY newtabtools.export.prefs.blocked "Pages bloquées">
 <!ENTITY newtabtools.export.prefs.gridsize "Nombre de lignes et de colonnes">
 <!ENTITY newtabtools.export.prefs.gridmargin "Marges choisies">
 <!ENTITY newtabtools.export.tiles.thumbs "Miniatures personnelles">
-<!ENTITY newtabtools.export.prefs.thumbs.position "État des miniatures">
+<!ENTITY newtabtools.export.prefs.thumbs.position "Position des miniatures">
 <!ENTITY newtabtools.export.annos.title "Titres personnels">
-<!ENTITY newtabtools.export.prefs.thumbs.hidebuttons "État des boutons Relâcher et Supprimer">
-<!ENTITY newtabtools.export.prefs.thumbs.hidefavicons "État des favicons">
+<!ENTITY newtabtools.export.prefs.thumbs.hidebuttons "Statut des boutons Relâcher et Bloquer">
+<!ENTITY newtabtools.export.prefs.thumbs.hidefavicons "Statut des favicons">
 <!ENTITY newtabtools.export.page.caption "Page Nouvel onglet">
 <!ENTITY newtabtools.export.prefs.launcher "Position de la barre de raccourcis">
-<!ENTITY newtabtools.export.prefs.recent.show "État des onglets récemment fermés">
+<!ENTITY newtabtools.export.prefs.recent.show "Statut des onglets récemment fermés">
 <!ENTITY newtabtools.export.page.background "Arrière-plan">
 <!ENTITY newtabtools.export.prefs.theme "Thème choisi">
-<!ENTITY newtabtools.export.historytiles "État des cases vides">
+<!ENTITY newtabtools.export.historytiles "Statut des cases vides">
 <!ENTITY newtabtools.export.foreground.opacity "Opacité choisie">

--- a/locale/fr/filter.dtd
+++ b/locale/fr/filter.dtd
@@ -1,6 +1,6 @@
-<!ENTITY title "Filter Browsing History Tiles">
-<!ENTITY description "This tool limits the number of tiles from your browsing history that appear for each domain. It does not affect pinned tiles.">
-<!ENTITY domainheader "Domain">
-<!ENTITY countheader "Max Tile Count">
-<!ENTITY addbuttonlabel "Add">
-<!ENTITY removebuttonlabel "Remove">
+<!ENTITY title "Filtrage des domaines">
+<!ENTITY description "Les cases vides sont remplies à l'aide de votre historique de navigation. Cet outil limite le nombre de cases occupées par chaque domaine. Il ne tient pas compte des cases épinglées.">
+<!ENTITY domainheader "Domaine">
+<!ENTITY countheader "Nombre max de cases">
+<!ENTITY addbuttonlabel "Ajouter">
+<!ENTITY removebuttonlabel "Supprimer">

--- a/locale/fr/newTab.dtd
+++ b/locale/fr/newTab.dtd
@@ -1,15 +1,15 @@
 <!ENTITY newtabtools.options.pointer "Cliquez ici pour commencer à personnaliser votre page « Nouvel onglet »">
 <!ENTITY newtabtools.page.show "Afficher la page « Nouvel onglet »">
 
-<!ENTITY newtabtools.pin-url.header "Ajouter un site :">
+<!ENTITY newtabtools.pin-url.header "Ajouter une page :">
 <!ENTITY newtabtools.pin-url.placeholder "Tapez ou sélectionnez une URL">
 <!ENTITY newtabtools.pin-url.button "Ajouter">
 
-<!ENTITY newtabtools.tile-header "Sites :">
+<!ENTITY newtabtools.tile-header "Pages :">
 
 <!ENTITY newtabtools.tile-selection.previousrow.tooltip "Rangée supérieure">
-<!ENTITY newtabtools.tile-selection.previous.tooltip "Site précédent">
-<!ENTITY newtabtools.tile-selection.next.tooltip "Site suivant">
+<!ENTITY newtabtools.tile-selection.previous.tooltip "Page précédente">
+<!ENTITY newtabtools.tile-selection.next.tooltip "Page suivante">
 <!ENTITY newtabtools.tile-selection.nextrow.tooltip "Rangée inférieure">
 
 <!ENTITY newtabtools.tile-thumbnail.label2 "Miniature :">
@@ -36,7 +36,7 @@
 
 <!ENTITY newtabtools.options-header "Options :">
 
-<!ENTITY newtabtools.filter.button "Filter…">
+<!ENTITY newtabtools.filter.button "Filtrer…">
 
 <!-- Data collection is not currently active, but this might change in future. -->
 <!ENTITY newtabtools.datacollection.optin "Aidez-nous à améliorer New Tab Tools en acceptant l'envoi de statistiques anonymes sur votre utilisation du module.">

--- a/locale/fr/newTabTools.properties
+++ b/locale/fr/newTabTools.properties
@@ -6,11 +6,11 @@ donate.accesskey = F
 
 toolsmenu.captureThumbnail = Capturer une miniature de cette page
 
-contextmenu.edit = Modifier ce site
-contextmenu.pin = Épingler ce site
-contextmenu.unpin = Relâcher ce site
-contextmenu.block = Supprimer ce site
+contextmenu.edit = Modifier cette page
+contextmenu.pin = Épingler cette page
+contextmenu.unpin = Relâcher cette page
+contextmenu.block = Bloquer cette page
 contextmenu.optionsWindows = Options de New Tab Tools
 contextmenu.optionsUnix = Préférences de New Tab Tools
 
-tileurl.empty = Aucun site enregistré
+tileurl.empty = Aucune page enregistrée

--- a/locale/fr/options.dtd
+++ b/locale/fr/options.dtd
@@ -16,9 +16,9 @@
 <!ENTITY newtabtools.options.launcher.left "À gauche">
 <!ENTITY newtabtools.options.launcher.right "À droite">
 <!ENTITY newtabtools.options.thumb-titlesize "Taille des titres">
-<!ENTITY newtabtools.options.historytiles "Cases vides remplies automatiquement">
+<!ENTITY newtabtools.options.historytiles "Cases vides remplies avec historique">
 <!ENTITY newtabtools.options.recent "Onglets récemment fermés">
-<!ENTITY newtabtools.options.thumb-buttons "Boutons Relâcher et Supprimer">
+<!ENTITY newtabtools.options.thumb-buttons "Boutons Relâcher et Bloquer">
 <!ENTITY newtabtools.options.locked "Cases non déplaçables">
 <!ENTITY newtabtools.options.favicons "Favicons">
 <!ENTITY newtabtools.options.thumb-contain "Miniatures non rognées">


### PR DESCRIPTION
Translated filter.dtd + changed some words here and there.

Notably, I decided to replace the word _site_ with _page_ (for English _tile_). Mozilla does use _site_ in its own French "New tab" page and I first decided to follow this, but it really doesn't make sense. "New tab" handles web pages after all, not websites.