### PR TITLE
Add ability to alter a tile's URL

### DIFF
--- a/webextension/_locales/en/messages.json
+++ b/webextension/_locales/en/messages.json
@@ -272,5 +272,11 @@
 	},
 	"tileurl_empty": {
 		"message": "Empty Tile"
+	},
+	"tile_url_placeholder": {
+		"message": "Type a new tile URL"
+	},
+	"tile_url_set": {
+		"message": "Set"
 	}
 }

--- a/webextension/newTab.css
+++ b/webextension/newTab.css
@@ -628,6 +628,9 @@ svg {
 }
 #options input[type="file"],
 #options-pinURL-input,
+#options-url-input {
+	flex: 1;
+}
 #options-title-input {
 	flex: 1;
 }

--- a/webextension/newTab.js
+++ b/webextension/newTab.js
@@ -266,6 +266,11 @@ var newTabTools = {
 		case 'options-next-row-tile':
 			this.selectedSiteIndex = (this._selectedSiteIndex + Prefs.columns) % Grid.cells.length;
 			break;
+		case 'options-url-set':
+			this.selectedSite.link.url = this.siteURLInput.value;
+			this.selectedSite.addTitle();
+			Tiles.putTile(this.selectedSite.link);
+			break;			
 		case 'options-savethumb':
 			let link = this.selectedSite.link;
 			let siteURL = link.url;
@@ -701,7 +706,7 @@ var newTabTools = {
 			this.siteThumbnail.style.backgroundImage =
 				this.siteThumbnail.style.backgroundColor =
 				this.setBgColourDisplay.style.backgroundColor = null;
-			this.siteURL.textContent = this.getString('tileurl_empty');
+			this.siteURLInput.value = this.getString('tileurl_empty');
 			this.setTitleInput.value = '';
 			this.saveCurrentThumbButton.disabled =
 				this.removeSavedThumbButton.disabled =
@@ -735,7 +740,7 @@ var newTabTools = {
 		this.tileNext.style.opacity = (column + 1 == columns) ? 0.25 : null;
 		this.tileNextRow.style.opacity = (row + 1 == rows) ? 0.25 : null;
 
-		this.siteURL.textContent = site.url;
+		this.siteURLInput.value = site.url;
 		let backgroundColor = site.link.backgroundColor;
 		this.siteThumbnail.style.backgroundColor =
 			this.setBgColourInput.value =
@@ -936,7 +941,8 @@ var newTabTools = {
 		'tileNext': 'options-next-tile',
 		'tileNextRow': 'options-next-row-tile',
 		'siteThumbnail': 'options-thumbnail',
-		'siteURL': 'options-url',
+		'siteURLInput': 'options-url-input',
+		'setURLButton': 'options-url-set',
 		'saveCurrentThumbButton': 'options-savethumb',
 		'setSavedThumbInput': 'options-savedthumb-input',
 		'removeSavedThumbButton': 'options-savedthumb-remove',

--- a/webextension/newTab.xhtml
+++ b/webextension/newTab.xhtml
@@ -95,7 +95,10 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 					<div class="options-row">
 						<button id="options-next-row-tile" class="arrow" data-title="tile_selection_nextrow_tooltip"></button>
 					</div>
-					<label id="options-url"></label>
+					<div class="options-row">
+						<input id="options-url-input" data-placeholder="tile_url_placeholder" />
+						<button id="options-url-set" data-message="tile_url_set"></button>
+					</div>
 					<label class="options-row-label" for="options-savedthumb-input" data-message="tile_savedthumb_label"></label>
 					<div class="options-row">
 						<button id="options-savethumb" data-message="tile_savedthumb_savecurrent"></button>


### PR DESCRIPTION
I've a bunch of tiles where nothing other than the server name changed and I couldn't see an obvious way of altering a tile's URL. So a quick tweak gave me this - a copy of the way that titles are altered.